### PR TITLE
hwcomposer: set brighness to zero on sleepDisplay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ pkg_check_modules(HWC_androidheaders REQUIRED android-headers)
 pkg_check_modules(HWC_hwcomposerwindow REQUIRED hwcomposer-egl)
 pkg_check_modules(HWC_hybriseglplatform REQUIRED hybris-egl-platform)
 pkg_check_modules(PKG_sync REQUIRED libsync)
+pkg_check_modules(PKG_udev REQUIRED libudev)
 
 qt_add_library(hwcomposer MODULE
                 hwcomposer/main.cpp
@@ -42,6 +43,7 @@ target_link_libraries(hwcomposer PUBLIC Qt::Core
                                         Qt::DBus
                                         ${EGL_LIBRARIES}
                                         ${PKG_sync_LIBRARIES}
+                                        ${PKG_udev_LIBRARIES}
                                         ${HWC_libhardware_LIBRARIES}
                                         ${HWC_androidheaders_LIBRARIES}
                                         ${HWC_hwcomposerwindow_LIBRARIES}
@@ -53,7 +55,8 @@ target_include_directories(hwcomposer PUBLIC ${EGL_INCLUDE_DIRS}
                                                 ${HWC_androidheaders_INCLUDE_DIRS}
                                                 ${HWC_hwcomposerwindow_INCLUDE_DIRS}
                                                 ${HWC_hybriseglplatform_INCLUDE_DIRS}
-                                                ${PKG_sync_INCLUDE_DIRS})
+                                                ${PKG_sync_INCLUDE_DIRS}
+                                                ${PKG_udev_INCLUDE_DIRS})
 
 install(TARGETS hwcomposer
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}/qt6/plugins/platforms/)

--- a/hwcomposer/hwcomposer_context.h
+++ b/hwcomposer/hwcomposer_context.h
@@ -54,6 +54,7 @@
 #include <QtGui/QSurfaceFormat>
 #include <QtGui/QImage>
 #include <EGL/egl.h>
+#include <libudev.h>
 
 #if (QT_VERSION >= QT_VERSION_CHECK(6, 0, 0))
 #include <QtGui/private/qeglplatformcontext_p.h>
@@ -99,6 +100,9 @@ private:
     bool display_off;
     bool window_created;
     qreal fps;
+
+    struct udev *udevInstance;
+    int restoreBrightness = 0;
 };
 
 QT_END_NAMESPACE


### PR DESCRIPTION
Some MTKs leave the panel on when turning off the screen. This means we need to manually set the brighness to zero on sleepDisplay and restore it back to its original value on unsleepDisplay.